### PR TITLE
Upstream load balance servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,14 @@ Backend servers:
   - `read_timeout`: The proxy read timeout, optional
   - `host_header`: Optionally set the Host header, you shouldn't need to set this unless you're trying to work around bugs in applications
 
+- `nginx_proxy_upstream_servers`: List of dictionaries of backend servers used for load-balancing with fields:
+  - `name`: The name of the load-balancing group (can be referenced in `nginx_proxy_backends.[].server`)
+  - `balance`: Load balancing algorithm
+  - `servers`: List of backend servers to be load-balanced
+
 - `nginx_proxy_streams`: List of dictionaries of backend streaming servers
   - `name`: A variable name used for grouping multiple upstream servers
-  - `port`: The port Nginx should lsiten on
+  - `port`: The port Nginx should listen on
   - `servers`: A list of backend servers, each item may include server specific parameters
   - `timeout`: Timeout between successive reads/writes
   - `connect_timeout`: Backend connection timeout

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -69,6 +69,9 @@ nginx_proxy_backends: []
 #  cache_validity: 1d
 #  websockets: False
 
+# List of dicts of upstream servers
+nginx_proxy_upstream_servers: []
+
 # List of redirections
 nginx_proxy_redirect_map: []
 #- match: /old/url

--- a/tasks/nginx-proxy-sites.yml
+++ b/tasks/nginx-proxy-sites.yml
@@ -13,6 +13,14 @@
   loop_control:
     loop_var: site
 
+- name: nginx | proxy upstream servers
+  become: yes
+  template:
+    src: nginx-confd-proxy-upstream.j2
+    dest: /etc/nginx/conf.d/proxy-upstream.conf
+  notify:
+    - restart nginx
+
 - name: nginx | create proxy ssl certificate directory
   become: yes
   file:

--- a/templates/nginx-conf.j2
+++ b/templates/nginx-conf.j2
@@ -36,6 +36,12 @@ http {
                       '"$http_user_agent" "$http_x_forwarded_for" '
                       '$request_time $upstream_cache_status';
 
+    log_format  main_timed_cache_upstream
+                      '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for" '
+                      '$request_time $upstream_cache_status $upstream_addr';
+
     access_log  /var/log/nginx/access.log  {{ nginx_proxy_log_format }};
 
     sendfile        on;

--- a/templates/nginx-confd-proxy-upstream.j2
+++ b/templates/nginx-confd-proxy-upstream.j2
@@ -1,0 +1,12 @@
+# Nginx upstream servers
+
+{% for item in nginx_proxy_upstream_servers %}
+upstream {{ item.name }} {
+{%   if item.balance | default('') | length > 0 %}
+  {{ item.balance }};
+{%   endif %}
+{%   for server in item.servers %}
+  server {{ server }};
+{%   endfor %}
+}
+{% endfor %}


### PR DESCRIPTION
Adds support for referencing a set of `upstream` servers instead of a single backend server: http://nginx.org/en/docs/http/load_balancing.html

New feature, tag `1.2.0`