### PR TITLE
Cachebuster port/proxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,14 @@ Role Variables: Main site
 
 - `nginx_proxy_server_name`: The server name, default `$hostname`.
   Set this if you are configuring a virtualhost.
+- `nginx_proxy_listen_http`: Listen on this port, default `80`.
+- `nginx_proxy_cachebuster_port`: An alternative port which can be used to force a cache refresh, disabled by default.
+  You should ensure this is firewalled.
+  You must also set `nginx_proxy_cachebuster_enabled` to enable this for individual sites.
 
 SSL variables:
 
-- `nginx_proxy_ssl`: If `True` enable SSL, default `False`
+- `nginx_proxy_ssl`: If `True` enable SSL on port `443`, default `False`
 - `nginx_proxy_hsts_age`: The max-age in seconds for a HSTS (HTTP Strict Transport Security) header, default is to omit this header
 - `nginx_proxy_http2`: If `True` enable HTTP2, default `False`
 - `nginx_proxy_force_ssl`: If `True` permanently redirect all `http` requests to `https`, default `False`
@@ -116,9 +120,11 @@ Caching:
 `nginx_proxy_cache_key` is always included as the default.
 - `nginx_proxy_cache_use_stale`: Situations in which stale cache results should be returned, see `defaults/main.yml` for default
 - `nginx_proxy_cache_lock_time`: Prevent multiple backend requests to the same object (subsequent requests will wait for the first to either return or time-out), default 1 minute
-- `nginx_proxy_cachebuster_port`: An alternative port which can be used to force a cache refresh, disabled by default. You should ensure this is firewalled. If SELinux is enabled and the port is not one that nginx can bind by default (typically 80, 81, 443, 488, 8008, 8009, 8443, 9000 are allowed by default) you must update your policy yourself.
+- `nginx_proxy_cachebuster_enabled`: Set to `True` to enable cache-busting on port `nginx_proxy_cachebuster_port`
 
 Warning: for convenience, put `nginx_proxy_cache_parent_path` on a separate partition (calculate size of the partition based on `max_size` set on disk caches).
+
+Warning: If SELinux is enabled you may need to update your policy yourself to allow Nginx to bind to a non-standard port (typically 80, 81, 443, 488, 8008, 8009, 8443, 9000 are allowed).
 
 
 Role Variables: Multiple sites

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -150,4 +150,4 @@ nginx_proxy_cache_use_stale: "error timeout invalid_header updating http_500 htt
 
 # Set this to True to ensure nginx_proxy_cachebuster_port takes effect, can
 # be per site
-nginx_proxy_cachebuster_enabled: False
+nginx_proxy_cachebuster_enabled: True

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,10 @@ nginx_proxy_log_format: main_timed_cache
 nginx_proxy_sites:
 - nginx_proxy_is_default: True
 
+# Requests on this port will force a cache refresh, global configuration
+# You must also set nginx_proxy_cachebuster_enabled: True
+nginx_proxy_cachebuster_port:
+
 
 ######################################################################
 # Defaults for per-site Nginx config /etc/nginx/*.d/[site].conf
@@ -98,6 +102,9 @@ nginx_proxy_websockets_enable: False
 # List of dicts of backend streaming servers
 nginx_proxy_streams: []
 
+# Listen on this port, set to 0 to disable
+nginx_proxy_listen_http: 80
+
 # Caching parameters
 # Parent path of Nginx disk caches
 nginx_proxy_cache_parent_path: /var/cache/nginx
@@ -141,5 +148,6 @@ nginx_proxy_cache_key_map: []
 # Use stale cache if these situations are encountered
 nginx_proxy_cache_use_stale: "error timeout invalid_header updating http_500 http_502 http_503 http_504"
 
-# Requests on this port will force a cache refresh
-nginx_proxy_cachebuster_port:
+# Set this to True to ensure nginx_proxy_cachebuster_port takes effect, can
+# be per site
+nginx_proxy_cachebuster_enabled: False

--- a/templates/nginx-confd-proxy.j2
+++ b/templates/nginx-confd-proxy.j2
@@ -27,7 +27,7 @@ server {
     add_header Strict-Transport-Security "max-age={{ site.nginx_proxy_hsts_age | default(nginx_proxy_hsts_age) }}";
 {%   endif %}
 {% endif %}
-{% if (site.nginx_proxy_cachebuster_enabled | default(nginx_proxy_cachebuster_enabled)) %}
+{% if (site.nginx_proxy_cachebuster_enabled | default(nginx_proxy_cachebuster_enabled)) and nginx_proxy_cachebuster_port %}
     listen       {{ nginx_proxy_cachebuster_port }};
 {% endif %}
     server_name  {{ site.nginx_proxy_server_name | default(nginx_proxy_server_name) }};

--- a/templates/nginx-confd-proxy.j2
+++ b/templates/nginx-confd-proxy.j2
@@ -1,8 +1,10 @@
 server {
-    listen       80
+{% if (site.nginx_proxy_listen_http | default(nginx_proxy_listen_http)) %}
+    listen       {{ nginx_proxy_listen_http }}
 {%   if (site.nginx_proxy_is_default | default(False)) %}
       default_server
 {%   endif %};
+{% endif %}
 
 {% if (site.nginx_proxy_ssl | default(nginx_proxy_ssl)) and (site.nginx_proxy_force_ssl | default(nginx_proxy_force_ssl)) %}
     server_name  {{ site.nginx_proxy_server_name | default(nginx_proxy_server_name) }};

--- a/templates/nginx-confd-proxy.j2
+++ b/templates/nginx-confd-proxy.j2
@@ -25,7 +25,7 @@ server {
     add_header Strict-Transport-Security "max-age={{ site.nginx_proxy_hsts_age | default(nginx_proxy_hsts_age) }}";
 {%   endif %}
 {% endif %}
-{% if nginx_proxy_cachebuster_port %}
+{% if (site.nginx_proxy_cachebuster_enabled | default(nginx_proxy_cachebuster_enabled)) %}
     listen       {{ nginx_proxy_cachebuster_port }};
 {% endif %}
     server_name  {{ site.nginx_proxy_server_name | default(nginx_proxy_server_name) }};


### PR DESCRIPTION
This modifies the behaviour of the global `nginx_proxy_cachebuster_port` to only take effect if `nginx_proxy_cachebuster_enabled` is `True` on a per-site basis. This allows different proxy servers to serve different ports whilst sharing the same cache.

Example: IDR where public ports are proxied to read-only OMERO, but the private cachebuster port is proxied to read-write OMERO.

The defaults are such that this should be a non-breaking change (see `templates/nginx-confd-proxy.j2`).

Tag: `1.3.0`