### PR TITLE
Fixing error message to refer to correct var

### DIFF
--- a/tasks/nginx-redirects.yml
+++ b/tasks/nginx-redirects.yml
@@ -5,7 +5,7 @@
 # (check both lists are empty, or both are non-empty)
 - name: nginx | check redirect configuration
   fail:
-    msg: "nginx_proxy_redirect_locations and nginx_proxy_redirect_map must be used together"
+    msg: "nginx_proxy_redirect_map_locations and nginx_proxy_redirect_map must be used together"
   when: (nginx_proxy_redirect_map_locations and not nginx_proxy_redirect_map) or (not nginx_proxy_redirect_map_locations and nginx_proxy_redirect_map)
 
 - name: nginx | proxy redirects config


### PR DESCRIPTION
The only place `nginx_proxy_redirect_locations` appears in the role is in the error message, the correct var must be `nginx_proxy_redirect_map_locations`:

```
LS27172:ansible-role-nginx-proxy kenny$ git grep nginx_proxy_redirect_locations
tasks/nginx-redirects.yml:    msg: "nginx_proxy_redirect_locations and nginx_proxy_redirect_map must be used together"
```