### PR TITLE
Add parameter for 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Nginx Proxy
 ===========
 
 [![Build Status](https://travis-ci.org/openmicroscopy/ansible-role-nginx-proxy.svg)](https://travis-ci.org/openmicroscopy/ansible-role-nginx-nginx)
-[![Ansible Role](https://img.shields.io/ansible/role/14762.svg)](https://galaxy.ansible.com/openmicroscopy/jekyll-build/)
+[![Ansible Role](https://img.shields.io/ansible/role/14769.svg)](https://galaxy.ansible.com/openmicroscopy/nginx-proxy/)
 
 Install Nginx for use as a front-end proxy.
 
@@ -30,7 +30,7 @@ Role Variables: Main site
 - `nginx_proxy_cachebuster_port`: An alternative port which can be used to force a cache refresh, disabled by default.
   You should ensure this is firewalled.
   You must also set `nginx_proxy_cachebuster_enabled` to enable this for individual sites.
-- `nginx_proxy_404`: An alternative port which can be used to force a cache refresh, disabled by default.
+- `nginx_proxy_404`: The URI to show for 404 errors, default ''.
 
 SSL variables:
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Role Variables: Main site
 - `nginx_proxy_cachebuster_port`: An alternative port which can be used to force a cache refresh, disabled by default.
   You should ensure this is firewalled.
   You must also set `nginx_proxy_cachebuster_enabled` to enable this for individual sites.
+- `nginx_proxy_404`: An alternative port which can be used to force a cache refresh, disabled by default.
 
 SSL variables:
 
@@ -165,6 +166,7 @@ Advanced configuration: force https, use HSTS, enable HTTP2
           server: http://a.internal
           cache_validity: 1h
         nginx_proxy_worker_processes: 4
+        nginx_proxy_404: '/404.html'
         nginx_proxy_ssl: True
         nginx_proxy_ssl_certificate: /etc/nginx/ssl/website.crt
         nginx_proxy_ssl_certificate_key: /etc/nginx/ssl/website.key

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 Nginx Proxy
 ===========
 
+[![Build Status](https://travis-ci.org/openmicroscopy/ansible-role-nginx-proxy.svg)](https://travis-ci.org/openmicroscopy/ansible-role-nginx-nginx)
+[![Ansible Role](https://img.shields.io/ansible/role/14762.svg)](https://galaxy.ansible.com/openmicroscopy/jekyll-build/)
+
 Install Nginx for use as a front-end proxy.
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,9 @@ nginx_proxy_log_format: main_timed_cache
 nginx_proxy_sites:
 - nginx_proxy_is_default: True
 
+# URI for 404 errors
+nginx_proxy_404:
+
 # Requests on this port will force a cache refresh, global configuration
 # You must also set nginx_proxy_cachebuster_enabled: True
 nginx_proxy_cachebuster_port:

--- a/templates/nginx-confd-proxy.j2
+++ b/templates/nginx-confd-proxy.j2
@@ -43,7 +43,7 @@ server {
 
 {%   if (site.nginx_proxy_404 | default(nginx_proxy_404)) %}
     error_page  404              {{ site.nginx_proxy_404 | default(nginx_proxy_404) }};
-{%   endif %};
+{%   endif %}
 
     # redirect server error pages to the static page /50x.html
     #

--- a/templates/nginx-confd-proxy.j2
+++ b/templates/nginx-confd-proxy.j2
@@ -41,7 +41,9 @@ server {
     #charset koi8-r;
     #access_log  /var/log/nginx/log/host.access.log  main;
 
-    #error_page  404              /404.html;
+{%   if (site.nginx_proxy_404 | default(nginx_proxy_404)) %}
+    error_page  404              {{ site.nginx_proxy_404 | default(nginx_proxy_404) }};
+{%   endif %};
 
     # redirect server error pages to the static page /50x.html
     #


### PR DESCRIPTION
Discussed with @kennethgillen and @manics during testing, this PR extends the nginx-proxy role to allow the comment `error_page 404` line to be configured by variable using a the `nginx_proxy_404` variable.

Proposed tag: `1.4.0`