### PR TITLE
Fix typo in nginx_proxy_block_locations

### DIFF
--- a/templates/nginx-confd-proxy.j2
+++ b/templates/nginx-confd-proxy.j2
@@ -52,7 +52,7 @@ server {
         root   /usr/share/nginx/html;
     }
 
-{% for item in (site.nginx_proxy_block_locations | default([nginx_proxy_block_locations])) %}
+{% for item in (site.nginx_proxy_block_locations | default(nginx_proxy_block_locations)) %}
     location {{ item }} {
         return 404;
     }


### PR DESCRIPTION
The template incorrectly puts `[` `]` around the global value of `nginx_proxy_block_locations` which should already be a list.

Current deployments of this role with the default `nginx_proxy_block_locations: []
` will have the following in `/etc/nginx/conf.d/proxy-default.conf` (which interestingly does not seem to be a syntax error):
```
    location [] {
        return 404;
    }
```
After application of this fix those three lines will be removed.

If you set:
```
nginx_proxy_block_locations:
- "^~ /django_prometheus"
```
you should get something like:
```
    location ^~ /django_prometheus {
        return 404;
    }
```