### PR TITLE
Use no_log on ssl cert copy

### DIFF
--- a/tasks/nginx-proxy-sites.yml
+++ b/tasks/nginx-proxy-sites.yml
@@ -56,6 +56,7 @@
     - "{{ nginx_proxy_sites }}"
   notify:
     - restart nginx
+  no_log: True
 
 - name: nginx | copy proxy ssl certificate key
   become: yes
@@ -72,3 +73,4 @@
     - "{{ nginx_proxy_sites }}"
   notify:
     - restart nginx
+  no_log: True


### PR DESCRIPTION
Sanitise output in preparation for logging with ara https://github.com/openmicroscopy/infrastructure/pull/282

```
...

TASK [openmicroscopy.nginx-proxy : nginx | copy proxy ssl certificate] *********
[0;31m--- before[0m
[0;31m[0m[0;32m+++ after: /Users/spli/work/management_tools/ssl-certs/idr_openmicroscopy_org-20170419-chained.cert[0m
[0;32m[0m[0;36m@@ -0,0 +1 @@[0m
[0;36m[0m[0;32m+ [[ Diff output has been hidden because 'no_log: true' was specified for this result ]][0m
[0;32m[0m
[0;33mchanged: [e3f02fa1-06e4-42f7-9991-ad3d772affde] => (item=(censored due to no_log))[0m
[0;36mskipping: [e3f02fa1-06e4-42f7-9991-ad3d772affde] => (item=(censored due to no_log)) [0m
[0;36mskipping: [e3f02fa1-06e4-42f7-9991-ad3d772affde] => (item=(censored due to no_log)) [0m
[0;36mskipping: [e3f02fa1-06e4-42f7-9991-ad3d772affde] => (item=(censored due to no_log)) [0m
[0;31m--- before[0m
[0;31m[0m[0;32m+++ after: /Users/spli/work/management_tools/ssl-certs/idr-demo_openmicroscopy_org-20160518-chained.cert[0m
[0;32m[0m[0;36m@@ -0,0 +1 @@[0m
[0;36m[0m[0;32m+ [[ Diff output has been hidden because 'no_log: true' was specified for this result ]][0m
[0;32m[0m
[0;33mchanged: [e3f02fa1-06e4-42f7-9991-ad3d772affde] => (item=(censored due to no_log))[0m

TASK [openmicroscopy.nginx-proxy : nginx | copy proxy ssl certificate key] *****
[0;31m--- before[0m
[0;31m[0m[0;32m+++ after: /Users/spli/work/management_tools/ssl-certs/idr_openmicroscopy_org-20170419.key[0m
[0;32m[0m[0;36m@@ -0,0 +1 @@[0m
[0;36m[0m[0;32m+ [[ Diff output has been hidden because 'no_log: true' was specified for this result ]][0m
[0;32m[0m
[0;33mchanged: [e3f02fa1-06e4-42f7-9991-ad3d772affde] => (item=(censored due to no_log))[0m
[0;36mskipping: [e3f02fa1-06e4-42f7-9991-ad3d772affde] => (item=(censored due to no_log)) [0m
[0;36mskipping: [e3f02fa1-06e4-42f7-9991-ad3d772affde] => (item=(censored due to no_log)) [0m
[0;36mskipping: [e3f02fa1-06e4-42f7-9991-ad3d772affde] => (item=(censored due to no_log)) [0m
[0;31m--- before[0m
[0;31m[0m[0;32m+++ after: /Users/spli/work/management_tools/ssl-certs/idr-demo_openmicroscopy_org-20160518.key[0m
[0;32m[0m[0;36m@@ -0,0 +1 @@[0m
[0;36m[0m[0;32m+ [[ Diff output has been hidden because 'no_log: true' was specified for this result ]][0m
[0;32m[0m
[0;33mchanged: [e3f02fa1-06e4-42f7-9991-ad3d772affde] => (item=(censored due to no_log))[0m

TASK [openmicroscopy.nginx-proxy : nginx | start service] **********************
[0;33mchanged: [e3f02fa1-06e4-42f7-9991-ad3d772affde][0m

RUNNING HANDLER [openmicroscopy.nginx : restart nginx] *************************
[0;33mchanged: [e3f02fa1-06e4-42f7-9991-ad3d772affde][0m
```