### PR TITLE
Allow additional config parameters to be added to nginx.conf 

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,8 @@ Advanced configuration: force https, use HSTS, enable HTTP2
         nginx_proxy_force_ssl: True
         nginx_proxy_hsts_age: 31536000
         nginx_proxy_conf_http:
-          - "client_max_body_size 500m;"
-          - "server_tokens off;"
+          - "client_max_body_size 500m"
+          - "server_tokens off"
 
 
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Role Variables: Main site
   You should ensure this is firewalled.
   You must also set `nginx_proxy_cachebuster_enabled` to enable this for individual sites.
 - `nginx_proxy_404`: The URI to show for 404 errors, default ''.
+- `nginx_proxy_conf_http`: add a list of strings to this variable to add each list item as additional lines to the `/etc/nginx/nginx.conf` file, for custom, advanced deployments. 
 
 SSL variables:
 
@@ -176,6 +177,11 @@ Advanced configuration: force https, use HSTS, enable HTTP2
         nginx_proxy_http2: True
         nginx_proxy_force_ssl: True
         nginx_proxy_hsts_age: 31536000
+        nginx_proxy_conf_http:
+          - "client_max_body_size 500m;"
+          - "server_tokens off;"
+
+
 
 
 Author Information

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -155,5 +155,5 @@ nginx_proxy_cache_use_stale: "error timeout invalid_header updating http_500 htt
 # be per site
 nginx_proxy_cachebuster_enabled: True
 
-# Each line of list to be added to `/etc/nginx/nginx.conf` section `http`
+# Each line of list to be added as a directive to `http` context defined in `/etc/nginx/nginx.conf`, will have a `;` added to end of line.
 nginx_proxy_conf_http: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -154,3 +154,6 @@ nginx_proxy_cache_use_stale: "error timeout invalid_header updating http_500 htt
 # Set this to True to ensure nginx_proxy_cachebuster_port takes effect, can
 # be per site
 nginx_proxy_cachebuster_enabled: True
+
+# Each line of list to be added to `/etc/nginx/nginx.conf` section `http`
+nginx_proxy_conf_http: []

--- a/templates/nginx-conf.j2
+++ b/templates/nginx-conf.j2
@@ -48,7 +48,7 @@ http {
     #tcp_nopush     on;
 
     {% for http_conf_line in nginx_proxy_conf_http -%}
-    {{ http_conf_line }}
+    {{ http_conf_line }};
     {%- endfor %}
 
     keepalive_timeout  65;

--- a/templates/nginx-conf.j2
+++ b/templates/nginx-conf.j2
@@ -47,9 +47,11 @@ http {
     sendfile        on;
     #tcp_nopush     on;
 
-    {% for http_conf_line in nginx_proxy_conf_http %}
+    {% if http_conf_line is not none %}
+      {% for http_conf_line in nginx_proxy_conf_http %}
 {{ http_conf_line }}
-    {% endfor %}
+      {% endfor %}
+    {% endif %}
 
     keepalive_timeout  65;
 

--- a/templates/nginx-conf.j2
+++ b/templates/nginx-conf.j2
@@ -47,11 +47,9 @@ http {
     sendfile        on;
     #tcp_nopush     on;
 
-    {% if nginx_proxy_conf_http is defined %}
-      {% for http_conf_line in nginx_proxy_conf_http %}
-{{ http_conf_line }}
-      {% endfor %}
-    {% endif %}
+    {% for http_conf_line in nginx_proxy_conf_http -%}
+    {{ http_conf_line }}
+    {%- endfor %}
 
     keepalive_timeout  65;
 

--- a/templates/nginx-conf.j2
+++ b/templates/nginx-conf.j2
@@ -47,7 +47,7 @@ http {
     sendfile        on;
     #tcp_nopush     on;
 
-    {% if http_conf_line is not none %}
+    {% if nginx_proxy_conf_http is not none %}
       {% for http_conf_line in nginx_proxy_conf_http %}
 {{ http_conf_line }}
       {% endfor %}

--- a/templates/nginx-conf.j2
+++ b/templates/nginx-conf.j2
@@ -47,7 +47,7 @@ http {
     sendfile        on;
     #tcp_nopush     on;
 
-    {% if nginx_proxy_conf_http is not none %}
+    {% if nginx_proxy_conf_http is defined %}
       {% for http_conf_line in nginx_proxy_conf_http %}
 {{ http_conf_line }}
       {% endfor %}

--- a/templates/nginx-conf.j2
+++ b/templates/nginx-conf.j2
@@ -1,6 +1,6 @@
 
 user  nginx;
-worker_processes  {{ nginx_proxy_worker_processes }};
+worker_processes {{ nginx_proxy_worker_processes }};
 
 error_log  /var/log/nginx/error.log warn;
 pid        /var/run/nginx.pid;
@@ -46,6 +46,10 @@ http {
 
     sendfile        on;
     #tcp_nopush     on;
+
+    {% for http_conf_line in nginx_proxy_conf_http %}
+{{ http_conf_line }}
+    {% endfor %}
 
     keepalive_timeout  65;
 


### PR DESCRIPTION
Allow additional parameters to be added to the `nginx.conf` `http` section:
e.g.

```
    - role: openmicroscopy.nginx_proxy
      nginx_proxy_worker_processes: "{{ ((ansible_processor_count * ansible_processor_cores) / 2) |round|int }}"
      nginx_proxy_http2: True
      nginx_proxy_force_ssl: False
      nginx_proxy_404: "/404.html"
      nginx_proxy_conf_http:
        - "client_max_body_size 2g;"
        - "#another commented setting;"
```

Resulting in: 
```
[root@ome-www-dev nginx]# git diff
diff --git a/nginx.conf b/nginx.conf
index b5bdcea..65e211d 100644
--- a/nginx.conf
+++ b/nginx.conf
@@ -47,6 +47,9 @@ http {
     sendfile        on;
     #tcp_nopush     on;

+    client_max_body_size 2g;
+    # another commented setting;
+
     keepalive_timeout  65;

     #gzip  on;
```
