### PR TITLE
nginx.conf: removing commented directives

### DIFF
--- a/templates/nginx-conf.j2
+++ b/templates/nginx-conf.j2
@@ -45,15 +45,12 @@ http {
     access_log  /var/log/nginx/access.log  {{ nginx_proxy_log_format }};
 
     sendfile        on;
-    #tcp_nopush     on;
 
     {% for http_conf_line in nginx_proxy_conf_http -%}
     {{ http_conf_line }};
     {%- endfor %}
 
     keepalive_timeout  65;
-
-    #gzip  on;
 
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
Remove 2x commented directives in nginx.conf, since this section is now editable via the variable `nginx_proxy_conf_http` as described in https://github.com/openmicroscopy/ansible-role-nginx-proxy/blame/master/README.md#L180