### PR TITLE
Use site.nginx_proxy_listen_http if set

### DIFF
--- a/templates/nginx-confd-proxy.j2
+++ b/templates/nginx-confd-proxy.j2
@@ -1,6 +1,6 @@
 server {
 {% if (site.nginx_proxy_listen_http | default(nginx_proxy_listen_http)) %}
-    listen       {{ nginx_proxy_listen_http }}
+    listen       {{ site.nginx_proxy_listen_http | default(nginx_proxy_listen_http) }}
 {%   if (site.nginx_proxy_is_default | default(False)) %}
       default_server
 {%   endif %};

--- a/tests/etc-nginx/conf.d/proxy-nocache.conf
+++ b/tests/etc-nginx/conf.d/proxy-nocache.conf
@@ -1,5 +1,5 @@
 server {
-    listen       80
+    listen       8009
 ;
 
 


### PR DESCRIPTION
Bug-fix: Previously this always used the default for `nginx_proxy_listen_http` instead of checking the site-specific variable.

--depends-on #13

Tag: `1.5.2`