### PR TITLE
Generate configuration for comparison

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -20,3 +20,82 @@
       nginx_proxy_redirect_map_locations:
         - location: "~ ^/map($|/)"
           code: 302
+
+      nginx_proxy_websockets_enable: True
+      nginx_proxy_upstream_servers:
+      - name: omeroreadonly
+        balance: ip_hash
+        servers:
+        - 127.0.1.1
+        - 127.0.1.2
+      - name: nocache
+        servers:
+        - 127.0.2.1
+      - name: other
+        servers:
+        - 127.0.3.1
+      nginx_proxy_backends:
+      - name: omeroreadonly
+        location: /cached
+        server: http://omeroreadonly
+        cache_validity: 1d
+        websockets: True
+        read_timeout: 86400
+        host_header: "$host"
+      nginx_proxy_forward_scheme_header: X-Forwarded-Proto-Omero-Web
+
+      nginx_proxy_cachebuster_port: 9000
+      nginx_proxy_cachebuster_enabled: False
+      nginx_proxy_cache_key: "$request_uri"
+      nginx_proxy_cache_key_map:
+      - match: "~^(.+[\\?\\&])_=\\d+(.*)$"
+        key: "$1$2"
+      nginx_proxy_cache_ignore_headers: '"Set-Cookie" "Vary" "Expires"'
+      nginx_proxy_cache_hide_headers:
+      - Set-Cookie
+      nginx_proxy_cache_match_uri:
+      - '"~/api/*"'
+      nginx_proxy_caches:
+      - name: default
+        maxsize: 1g
+        keysize: 1m
+        inactive: 180d
+        match:
+        - default
+
+      nginx_proxy_sites:
+        - nginx_proxy_is_default: True
+        - nginx_proxy_server_name: other
+          nginx_proxy_cachebuster_enabled: True
+          nginx_proxy_backends:
+          - name: other
+            location: /other
+            server: http://other
+            cache_validity: 1d
+        - nginx_proxy_server_name: nocache
+          nginx_proxy_cachebuster_enabled: False
+          nginx_proxy_listen_http: 8009
+          nginx_proxy_ssl: False
+          nginx_proxy_backends:
+          - name: nocache
+            location: /nocache
+            server: http://nocache
+            read_timeout: 600
+
+      nginx_proxy_block_locations:
+      - "^~ /blocked"
+
+      nginx_proxy_streams:
+      - name: idrrsync
+        port: 873
+        servers:
+        - "127.0.100.1:873 max_fails=3 fail_timeout=30s"
+        connect_timeout: 1s
+        timeout: 3s
+
+  tasks:
+    - name: Copy reference files
+      become: yes
+      copy:
+        dest: /root/etc-nginx/
+        src: tests/etc-nginx/

--- a/tests/etc-nginx/conf.d/default.conf
+++ b/tests/etc-nginx/conf.d/default.conf
@@ -1,0 +1,1 @@
+# This file is intentionally blank (Ansible)

--- a/tests/etc-nginx/conf.d/example_ssl.conf
+++ b/tests/etc-nginx/conf.d/example_ssl.conf
@@ -1,0 +1,1 @@
+# This file is intentionally blank (Ansible)

--- a/tests/etc-nginx/conf.d/proxy-cache.conf
+++ b/tests/etc-nginx/conf.d/proxy-cache.conf
@@ -1,0 +1,33 @@
+# Nginx caches
+proxy_cache_path /var/cache/nginx/default levels=1:2 keys_zone=default:1m max_size=1g inactive=180d use_temp_path=off;
+
+# Disable/enable caching for particular URLs
+#map $request_uri $uri_skip_cache
+map $request_uri $skip_cache
+{
+    default 1;
+    "~/api/*" 0;
+}
+
+#map $args $skip_cache
+#{
+#    default $uri_skip_cache;
+###}
+
+map $server_port $cache_refresh
+{
+    default $skip_cache;
+    9000 1;
+}
+
+# Use different caches for different URLs
+map $request_uri $cache_zone_name
+{
+    default default;
+}
+
+map $request_uri $cache_key
+{
+    default $request_uri;
+    ~^(.+[\?\&])_=\d+(.*)$ $1$2;
+}

--- a/tests/etc-nginx/conf.d/proxy-default.conf
+++ b/tests/etc-nginx/conf.d/proxy-default.conf
@@ -1,0 +1,79 @@
+server {
+    listen       80
+      default_server
+;
+
+
+    server_name  $hostname;
+
+
+    #charset koi8-r;
+    #access_log  /var/log/nginx/log/host.access.log  main;
+
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    location ^~ /blocked {
+        return 404;
+    }
+
+
+
+    # Common proxy headers
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto-Omero-Web $scheme;
+
+    port_in_redirect off;
+
+    location ~ ^/map($|/) {
+        return 302 $redirect_uri;
+    }
+
+    location /direct {
+        return 301 /redirect;
+    }
+    location /redirect/ {
+        return 302 /default;
+    }
+    location ^~ /default {
+        alias /usr/share/nginx/html;
+    }
+
+    location /cached {
+        proxy_pass http://omeroreadonly;
+        proxy_redirect http://omeroreadonly $scheme://$server_name;
+
+        proxy_cache            $cache_zone_name;
+        proxy_cache_key        $cache_key;
+        proxy_cache_valid      200 1d;
+        proxy_cache_methods    GET HEAD; # Only GET and HEAD methods apply
+        proxy_cache_use_stale  error timeout invalid_header updating http_500 http_502 http_503 http_504;
+        proxy_cache_bypass     $cache_refresh;
+        proxy_no_cache         $skip_cache;
+
+
+        proxy_cache_lock          on;
+        proxy_cache_lock_age      1m;
+        proxy_cache_lock_timeout  1m;
+
+        proxy_ignore_headers   "Set-Cookie" "Vary" "Expires";
+        proxy_hide_header Set-Cookie;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        proxy_read_timeout 86400;
+
+        proxy_set_header Host $host;
+    }
+
+
+}

--- a/tests/etc-nginx/conf.d/proxy-nocache.conf
+++ b/tests/etc-nginx/conf.d/proxy-nocache.conf
@@ -1,0 +1,59 @@
+server {
+    listen       80
+;
+
+
+    server_name  nocache;
+
+
+    #charset koi8-r;
+    #access_log  /var/log/nginx/log/host.access.log  main;
+
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    location ^~ /blocked {
+        return 404;
+    }
+
+
+
+    # Common proxy headers
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto-Omero-Web $scheme;
+
+    port_in_redirect off;
+
+    location ~ ^/map($|/) {
+        return 302 $redirect_uri;
+    }
+
+    location /direct {
+        return 301 /redirect;
+    }
+    location /redirect/ {
+        return 302 /default;
+    }
+    location ^~ /default {
+        alias /usr/share/nginx/html;
+    }
+
+    location /nocache {
+        proxy_pass http://nocache;
+        proxy_redirect http://nocache $scheme://$server_name;
+
+
+
+        proxy_read_timeout 600;
+
+    }
+
+
+}

--- a/tests/etc-nginx/conf.d/proxy-other.conf
+++ b/tests/etc-nginx/conf.d/proxy-other.conf
@@ -1,0 +1,74 @@
+server {
+    listen       80
+;
+
+
+    listen       9000;
+    server_name  other;
+
+
+    #charset koi8-r;
+    #access_log  /var/log/nginx/log/host.access.log  main;
+
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    location ^~ /blocked {
+        return 404;
+    }
+
+
+
+    # Common proxy headers
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto-Omero-Web $scheme;
+
+    port_in_redirect off;
+
+    location ~ ^/map($|/) {
+        return 302 $redirect_uri;
+    }
+
+    location /direct {
+        return 301 /redirect;
+    }
+    location /redirect/ {
+        return 302 /default;
+    }
+    location ^~ /default {
+        alias /usr/share/nginx/html;
+    }
+
+    location /other {
+        proxy_pass http://other;
+        proxy_redirect http://other $scheme://$server_name;
+
+        proxy_cache            $cache_zone_name;
+        proxy_cache_key        $cache_key;
+        proxy_cache_valid      200 1d;
+        proxy_cache_methods    GET HEAD; # Only GET and HEAD methods apply
+        proxy_cache_use_stale  error timeout invalid_header updating http_500 http_502 http_503 http_504;
+        proxy_cache_bypass     $cache_refresh;
+        proxy_no_cache         $skip_cache;
+
+
+        proxy_cache_lock          on;
+        proxy_cache_lock_age      1m;
+        proxy_cache_lock_timeout  1m;
+
+        proxy_ignore_headers   "Set-Cookie" "Vary" "Expires";
+        proxy_hide_header Set-Cookie;
+
+
+
+    }
+
+
+}

--- a/tests/etc-nginx/conf.d/proxy-redirect.conf
+++ b/tests/etc-nginx/conf.d/proxy-redirect.conf
@@ -1,0 +1,7 @@
+# Nginx redirection map
+map $request_uri $redirect_uri
+{
+    default /;
+    /map?search=abc1 /redirectmap?query=def2;
+    ~/map /redirectmap;
+}

--- a/tests/etc-nginx/conf.d/proxy-upstream.conf
+++ b/tests/etc-nginx/conf.d/proxy-upstream.conf
@@ -1,0 +1,13 @@
+# Nginx upstream servers
+
+upstream omeroreadonly {
+  ip_hash;
+  server 127.0.1.1;
+  server 127.0.1.2;
+}
+upstream nocache {
+  server 127.0.2.1;
+}
+upstream other {
+  server 127.0.3.1;
+}

--- a/tests/etc-nginx/conf.d/proxy-websockets.conf
+++ b/tests/etc-nginx/conf.d/proxy-websockets.conf
@@ -1,0 +1,6 @@
+# Global configuration to support websocket proxies
+
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+}

--- a/tests/etc-nginx/nginx.conf
+++ b/tests/etc-nginx/nginx.conf
@@ -1,0 +1,53 @@
+
+user  nginx;
+worker_processes 1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+stream {
+    include /etc/nginx/stream-conf.d/*.conf;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    log_format  main_timed
+                      '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for" '
+                      '$request_time';
+
+    log_format  main_timed_cache
+                      '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for" '
+                      '$request_time $upstream_cache_status';
+
+    log_format  main_timed_cache_upstream
+                      '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for" '
+                      '$request_time $upstream_cache_status $upstream_addr';
+
+    access_log  /var/log/nginx/access.log  main_timed_cache;
+
+    sendfile        on;
+
+    
+    keepalive_timeout  65;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/tests/etc-nginx/stream-conf.d/proxy-streams.conf
+++ b/tests/etc-nginx/stream-conf.d/proxy-streams.conf
@@ -1,0 +1,9 @@
+upstream idrrsync_server {
+    server 127.0.100.1:873 max_fails=3 fail_timeout=30s;
+}
+server {
+    listen 873;
+    proxy_connect_timeout 1s;
+    proxy_timeout 3s;
+    proxy_pass idrrsync_server;
+}

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -28,3 +28,16 @@ def test_redirects(Command, uri, expecturi, expectcode):
 def test_get_alias(Command):
     out = Command.check_output("curl http://localhost/default/")
     assert '<title>Welcome to nginx!</title>' in out
+
+
+@pytest.mark.parametrize("path", [
+    'nginx.conf',
+    'conf.d',
+    'stream-conf.d',
+])
+def test_compare_config(Command, path):
+    # Check the exit code separately so that the diff is printed out first
+    c = Command('diff -Nur /root/etc-nginx/%s /etc/nginx/%s' % (
+        path, path))
+    assert c.stdout == ''
+    assert c.rc == 0


### PR DESCRIPTION
This is a first step to testing this role. This adds a reference configuration against which the deployed configuration is compared. This means when this role is modified the changes made to the expected configuration are clear, even if they're not functionally tested.