### PR TITLE
Addition of NGINX log variables 

### DIFF
--- a/templates/nginx-conf.j2
+++ b/templates/nginx-conf.j2
@@ -19,28 +19,28 @@ stream {
 http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
-
-    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+    log_format  main
+                      '$server_name $remote_addr - $remote_user [$time_local] "$host" "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
     log_format  main_timed
-                      '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$server_name $remote_addr - $remote_user [$time_local] "$host" "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for" '
                       '$request_time';
 
     log_format  main_timed_cache
-                      '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$server_name $remote_addr - $remote_user [$time_local] "$host" "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for" '
                       '$request_time $upstream_cache_status';
 
     log_format  main_timed_cache_upstream
-                      '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$server_name $remote_addr - $remote_user [$time_local] "$host" "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for" '
-                      '$request_time $upstream_cache_status $upstream_addr';
+                      '$request_time $upstream_response_time $upstream_cache_status $upstream_addr';
 
     access_log  /var/log/nginx/access.log  {{ nginx_proxy_log_format }};
 


### PR DESCRIPTION
New NGINX log format variables which include:

   `server_name` from the `server` in the config which is processing the request (i.e. like the Apache concept of "virtualhost"), [see ref](https://www.scalyr.com/community/guides/an-in-depth-guide-to-nginx-metrics#request_time)
  request host header value (usually but not always the same as the previous), [see ref](https://www.scalyr.com/community/guides/an-in-depth-guide-to-nginx-metrics#request_time)
  an additional valuable metric: [upstream server response time](http://nginx.org/en/docs/http/ngx_http_upstream_module.html?&_ga=2.30230204.220483061.1525946833-353377040.1521823980#var_upstream_response_time), so we can better isolate issues.

Travis test expected output also updated so it should match the newly generated output.

Improvements would be to allow different log formats per `server` definition, and also a custom log format. Though the latter _could_ be achieved through `nginx_proxy_conf_http` if required.

--fixes #17 