### PR TITLE
Background cache updates and custom log format (Fixes required for the IDR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Role Variables: Main site
   You should ensure this is firewalled.
   You must also set `nginx_proxy_cachebuster_enabled` to enable this for individual sites.
 - `nginx_proxy_404`: The URI to show for 404 errors, default ''.
-- `nginx_proxy_conf_http`: add a list of strings to this variable to add each list item as additional lines to the `/etc/nginx/nginx.conf` file, for custom, advanced deployments. 
+- `nginx_proxy_log_format_custom`: Additional Nginx log format, will be named `custom`. This only adds the format, to use it as the default log format you should set `nginx_proxy_log_format: custom`.
+- `nginx_proxy_conf_http`: add a list of strings to this variable to add each list item as additional lines to the `/etc/nginx/nginx.conf` file, for custom, advanced deployments.
 
 SSL variables:
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Caching:
   - `match`: Match in nginx_proxy_cache_key
   - `key`: The cache key
 `nginx_proxy_cache_key` is always included as the default.
-- `nginx_proxy_cache_use_stale`: Situations in which stale cache results should be returned, see `defaults/main.yml` for default
+- `nginx_proxy_cache_use_stale`: Situations in which stale cache results should be returned, see `defaults/main.yml` for default, if enabled this will also turn on background updates.
 - `nginx_proxy_cache_lock_time`: Prevent multiple backend requests to the same object (subsequent requests will wait for the first to either return or time-out), default 1 minute
 - `nginx_proxy_cachebuster_enabled`: Set to `True` to enable cache-busting on port `nginx_proxy_cachebuster_port`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,9 @@ nginx_proxy_worker_connections: 1024
 # Format for access.log, see templates/nginx-conf.j2 for predefined formats
 nginx_proxy_log_format: main_timed_cache
 
+# Custom log format
+nginx_proxy_log_format_custom: ''
+
 # Array of dictionaries with per-site parameters (same as main site)
 nginx_proxy_sites:
   - nginx_proxy_is_default: true

--- a/molecule/default/files/etc-nginx/conf.d/proxy-default.conf
+++ b/molecule/default/files/etc-nginx/conf.d/proxy-default.conf
@@ -55,6 +55,7 @@ server {
         proxy_cache_valid      200 1d;
         proxy_cache_methods    GET HEAD; # Only GET and HEAD methods apply
         proxy_cache_use_stale  error timeout invalid_header updating http_500 http_502 http_503 http_504;
+        proxy_cache_background_update on;
         proxy_cache_bypass     $cache_refresh;
         proxy_no_cache         $skip_cache;
 

--- a/molecule/default/files/etc-nginx/conf.d/proxy-other.conf
+++ b/molecule/default/files/etc-nginx/conf.d/proxy-other.conf
@@ -55,6 +55,7 @@ server {
         proxy_cache_valid      200 1d;
         proxy_cache_methods    GET HEAD; # Only GET and HEAD methods apply
         proxy_cache_use_stale  error timeout invalid_header updating http_500 http_502 http_503 http_504;
+        proxy_cache_background_update on;
         proxy_cache_bypass     $cache_refresh;
         proxy_no_cache         $skip_cache;
 

--- a/molecule/default/files/etc-nginx/nginx.conf
+++ b/molecule/default/files/etc-nginx/nginx.conf
@@ -20,28 +20,27 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    log_format  main
-                      '$server_name $remote_addr - $remote_user [$time_local] "$host" "$request" '
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
     log_format  main_timed
-                      '$server_name $remote_addr - $remote_user [$time_local] "$host" "$request" '
+                      '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for" '
                       '$request_time';
 
     log_format  main_timed_cache
-                      '$server_name $remote_addr - $remote_user [$time_local] "$host" "$request" '
+                      '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for" '
                       '$request_time $upstream_cache_status';
 
     log_format  main_timed_cache_upstream
-                      '$server_name $remote_addr - $remote_user [$time_local] "$host" "$request" '
+                      '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for" '
-                      '$request_time $upstream_response_time $upstream_cache_status $upstream_addr';
+                      '$request_time $upstream_cache_status $upstream_addr';
 
     access_log  /var/log/nginx/access.log  main_timed_cache;
 

--- a/templates/nginx-conf.j2
+++ b/templates/nginx-conf.j2
@@ -43,6 +43,10 @@ http {
                       '"$http_user_agent" "$http_x_forwarded_for" '
                       '$request_time $upstream_response_time $upstream_cache_status $upstream_addr';
 
+    {% if nginx_proxy_log_format_custom | length > 0 -%}
+    log_format custom {{ nginx_proxy_log_format_custom }};
+    {% endif -%}
+
     access_log  /var/log/nginx/access.log  {{ nginx_proxy_log_format }};
 
     sendfile        on;

--- a/templates/nginx-conf.j2
+++ b/templates/nginx-conf.j2
@@ -19,7 +19,6 @@ stream {
 http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
-
     log_format  main
                       '$server_name $remote_addr - $remote_user [$time_local] "$host" "$request" '
                       '$status $body_bytes_sent "$http_referer" '

--- a/templates/nginx-conf.j2
+++ b/templates/nginx-conf.j2
@@ -19,28 +19,28 @@ stream {
 http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
-    log_format  main
-                      '$server_name $remote_addr - $remote_user [$time_local] "$host" "$request" '
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
     log_format  main_timed
-                      '$server_name $remote_addr - $remote_user [$time_local] "$host" "$request" '
+                      '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for" '
                       '$request_time';
 
     log_format  main_timed_cache
-                      '$server_name $remote_addr - $remote_user [$time_local] "$host" "$request" '
+                      '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for" '
                       '$request_time $upstream_cache_status';
 
     log_format  main_timed_cache_upstream
-                      '$server_name $remote_addr - $remote_user [$time_local] "$host" "$request" '
+                      '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for" '
-                      '$request_time $upstream_response_time $upstream_cache_status $upstream_addr';
+                      '$request_time $upstream_cache_status $upstream_addr';
 
     {% if nginx_proxy_log_format_custom | length > 0 -%}
     log_format custom {{ nginx_proxy_log_format_custom }};

--- a/templates/nginx-confd-proxy.j2
+++ b/templates/nginx-confd-proxy.j2
@@ -135,6 +135,7 @@ server {
         proxy_cache_methods    GET HEAD; # Only GET and HEAD methods apply
 {%     if nginx_proxy_cache_use_stale %}
         proxy_cache_use_stale  {{ nginx_proxy_cache_use_stale }};
+        proxy_cache_background_update on;
 {%     endif %}
         proxy_cache_bypass     $cache_refresh;
         proxy_no_cache         $skip_cache;


### PR DESCRIPTION
1. `proxy_cache_background_update` is automatically set to on when `proxy_cache_use_stale` is set. This seems a reasonable default so I've decided not to add another parameter to the role.
2. Adds support for a custom log format `nginx_proxy_log_format_custom`. This is needed because the last update changed the built-in log formats: https://github.com/IDR/deployment/issues/141